### PR TITLE
Added setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+
+
+from setuptools import setup
+
+# Main module target
+setup(name='vae-flow',
+      author="Andy Miller",
+      license="MIT",
+      version='0.0.0',
+      packages=['vae-flow'],
+      ext_modules=[]
+     )


### PR DESCRIPTION
Makes it easy to add `vae-flow` to path using `python setup.py develop` and remove it with `python setup.py develop --uninstall`.
